### PR TITLE
Change file format layout

### DIFF
--- a/kernel/lcfs-reader.h
+++ b/kernel/lcfs-reader.h
@@ -18,15 +18,6 @@ struct lcfs_context_s *lcfs_create_ctx(char *descriptor_path);
 
 void lcfs_destroy_ctx(struct lcfs_context_s *ctx);
 
-struct lcfs_dentry_s *lcfs_get_dentry(struct lcfs_context_s *ctx, size_t index,
-				      struct lcfs_dentry_s *buffer);
-
-/* Copy the specified VDATA to DEST.  DEST must be preallocated and must be at least
-   vdata.len bytes.  */
-void *lcfs_get_vdata(struct lcfs_context_s *ctx,
-		     const struct lcfs_vdata_s vdata,
-		     void *dest);
-
 struct lcfs_inode_s *lcfs_get_ino_index(struct lcfs_context_s *ctx,
 					lcfs_off_t index,
 					struct lcfs_inode_s *buffer);
@@ -35,17 +26,12 @@ struct lcfs_inode_s *lcfs_dentry_inode(struct lcfs_context_s *ctx,
 				       struct lcfs_dentry_s *node,
 				       struct lcfs_inode_s *buffer);
 
-const char *lcfs_c_string(struct lcfs_context_s *ctx, struct lcfs_vdata_s vdata,
-			  char *buf, size_t max);
-
 static inline u64 lcfs_dentry_ino(struct lcfs_dentry_s *d)
 {
 	return d->inode_index;
 }
 
-lcfs_off_t lcfs_get_root_index(struct lcfs_context_s *ctx);
-
-struct lcfs_dir_s *lcfs_get_dir(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino);
+struct lcfs_dir_s *lcfs_get_dir(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, lcfs_off_t index);
 
 struct lcfs_xattr_header_s *lcfs_get_xattrs(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino);
 ssize_t lcfs_list_xattrs(struct lcfs_xattr_header_s *xattrs, char *names, size_t size);
@@ -57,10 +43,8 @@ int lcfs_iterate_dir(struct lcfs_dir_s *dir, loff_t first, lcfs_dir_iter_cb cb, 
 
 int lcfs_lookup(struct lcfs_dir_s *dir, const char *name, size_t name_len, lcfs_off_t *index);
 
-const char *lcfs_get_payload(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, void *buf);
+char *lcfs_dup_payload_path(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, lcfs_off_t index);
 
-char *lcfs_dup_payload_path(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino);
-
-int lcfs_get_backing(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, loff_t *out_size, char **out_path);
+int lcfs_get_backing(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, lcfs_off_t index, loff_t *out_size, char **out_path);
 
 #endif

--- a/kernel/lcfs.h
+++ b/kernel/lcfs.h
@@ -32,8 +32,8 @@ typedef u64 lcfs_off_t;
 typedef lcfs_off_t lcfs_c_str_t;
 
 struct lcfs_vdata_s {
-	lcfs_off_t off;
-	lcfs_off_t len;
+	u32 off;
+	u32 len;
 } __attribute__((packed));
 
 struct lcfs_header_s {
@@ -42,6 +42,7 @@ struct lcfs_header_s {
 	u16 unused2;
 
 	u32 inode_len;
+	lcfs_off_t data_offset;
 
 	u64 unused3[3];
 } __attribute__((packed));
@@ -80,16 +81,16 @@ struct lcfs_inode_s {
 	/* Variable len data.  */
 	struct lcfs_vdata_s xattrs;
 
-	union {
-		/* Offset and length to the content of the directory.  */
-		struct lcfs_vdata_s dir;
-
-		/* Payload used for symlinks.  */
-		struct lcfs_vdata_s payload;
-
-		/* Payload used for regular files.  */
-		struct lcfs_vdata_s backing;
-	} u;
+	/* This is the size of the type specific data that comes directly after
+	   the inode in the file. Of this type:
+	   *
+	   * directory: lcfs_dir_s
+	   * regular file: lcfs_backing_s
+	   * symlink: the target link
+	   *
+	   * Canonically payload_length is 0 for empty dir/file/symlink.
+	   */
+	u32 payload_length;
 } __attribute__((packed));
 
 struct lcfs_dentry_s {

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -29,8 +29,8 @@ typedef uint64_t lcfs_off_t;
 typedef lcfs_off_t lcfs_c_str_t;
 
 struct lcfs_vdata_s {
-	lcfs_off_t off;
-	lcfs_off_t len;
+	uint32_t off;
+	uint32_t len;
 } __attribute__((packed));
 
 struct lcfs_header_s {
@@ -39,6 +39,7 @@ struct lcfs_header_s {
 	uint16_t unused2;
 
 	uint32_t inode_len;
+	lcfs_off_t data_offset;
 
 	uint64_t unused3[3];
 } __attribute__((packed));
@@ -54,7 +55,6 @@ struct lcfs_backing_s {
 
 #define lcfs_backing_size(_payload_len) (sizeof(struct lcfs_backing_s) + (_payload_len))
 
-
 struct lcfs_inode_s {
 	uint32_t st_mode; /* File type and mode.  */
 	uint32_t st_nlink; /* Number of hard links.  */
@@ -68,16 +68,16 @@ struct lcfs_inode_s {
 	/* Variable len data.  */
 	struct lcfs_vdata_s xattrs;
 
-	union {
-		/* Offset and length to the content of the directory.  */
-		struct lcfs_vdata_s dir;
-
-		/* Payload used for symlinks.  */
-		struct lcfs_vdata_s payload;
-
-		/* Payload used for regular files.  */
-		struct lcfs_vdata_s backing;
-	} u;
+	/* This is the size of the type specific data that comes directly after
+	   the inode in the file. Of this type:
+	   *
+	   * directory: lcfs_dir_s
+	   * regular file: lcfs_backing_s
+	   * symlink: the target link
+	   *
+	   * Canonically payload_length is 0 for empty dir/file/symlink.
+	   */
+	uint32_t payload_length;
 } __attribute__((packed));
 
 struct lcfs_dentry_s {


### PR DESCRIPTION
This changes the main format of the descriptor. It is now
in two parts, the first is the inode data table which statrts
(with the root inode) directly after the header. This contains
an array lcfs_inode_s, each optionally followed by the payload of that
inode which is either lcfs_backing_s, lcfs_dir_s, or a symlink target.

The second part is a variable data accesses with vdata like before,
but now only used by xattrs. The size of the inode table is in the
header so we can know where the variable data starts.

With these changes the descriptor size for my testcase goes from 3.3Mb
to 3.0Mb.

Some other changes as part of this:

Inode order is more sane, its stored in breadth-first from the root.

The vdata are now indexed only by 32bit, as we're unlikely to need
more than 4GB of xattrs.

link targets are now stored without terminating zero.

We're better at canonicalizing empty payloads.

Writing the descriptor now doesn't need to build a huge vdata, because
we can stream the output of the inodes and payloads, so memory use is
better.